### PR TITLE
Fix AIRouterLLM initialization and model switching issues

### DIFF
--- a/GopiAI-CrewAI/crewai_api_server.py
+++ b/GopiAI-CrewAI/crewai_api_server.py
@@ -540,13 +540,13 @@ def update_provider_model_state():
             return jsonify({"error": "Missing JSON data"}), 400
             
         provider = data.get("provider")
-        model_id = data.get("model_id")
+        model_id = data.get("model_id", "")
         
-        if not provider or not model_id:
-            return jsonify({"error": "Both 'provider' and 'model_id' are required"}), 400
+        if not provider:
+            return jsonify({"error": "The 'provider' field is required"}), 400
         
         # Обновляем состояние
-        update_state(provider, model_id)
+        save_state(provider, model_id)
         
         return jsonify({
             "status": "success",

--- a/GopiAI-CrewAI/tools/gopiai_integration/ai_router_llm.py
+++ b/GopiAI-CrewAI/tools/gopiai_integration/ai_router_llm.py
@@ -41,13 +41,19 @@ class AIRouterLLM(BaseLLM):
     """
     logger: ClassVar[logging.Logger] = logging.getLogger(__name__)
     model_configs: dict = Field(default_factory=dict)
-    def __init__(self, **kwargs):
+    def __init__(self, model_config_manager=None, **kwargs):
         super().__init__(**kwargs)
         self.model_configs = {m['id']: m for m in LLM_MODELS_CONFIG}
         # Инициализируем менеджер конфигураций как single source of truth
         try:
-            self.model_config_manager = get_model_config_manager()
-            self.logger.info("✅ AIRouterLLM инициализирован с ModelConfigurationManager (SSOT)")
+            # Используем переданный model_config_manager, если он есть
+            if model_config_manager is not None:
+                self.model_config_manager = model_config_manager
+                self.logger.info("✅ AIRouterLLM инициализирован с переданным ModelConfigurationManager")
+            else:
+                # Иначе получаем его стандартным способом
+                self.model_config_manager = get_model_config_manager()
+                self.logger.info("✅ AIRouterLLM инициализирован с ModelConfigurationManager (SSOT)")
         except Exception as e:
             # Создаем пустой объект model_config_manager, чтобы избежать ошибок при обращении
             from types import SimpleNamespace


### PR DESCRIPTION
## Description
This PR fixes two critical issues in the GopiAI system:

1. **AIRouterLLM Initialization Error**: Fixed the error `"AIRouterLLM" object has no field "model_config_manager"` that was occurring during emotional classifier initialization. The AIRouterLLM class now properly handles the model_config_manager parameter when it's passed during initialization.

2. **Model Switching Between OpenRouter and Gemini**: Fixed the issue with model switching by updating the `/internal/state` endpoint to:
   - Make the model_id parameter optional
   - Only require the provider field
   - Fix the function call from `update_state` to `save_state`

## Changes Made
- Modified `AIRouterLLM.__init__` to explicitly accept and use the model_config_manager parameter
- Updated the `/internal/state` endpoint to handle empty model_id values
- Fixed the function call in the endpoint to use the correct save_state function

## Testing
These changes should be tested by:
1. Verifying that the emotional classifier initializes without errors
2. Testing model switching between OpenRouter and Gemini providers
3. Verifying that the filesystem_tools are properly loaded and usable

## Related Issues
This PR addresses the following issues mentioned in the logs:
- "AIRouterLLM" object has no field "model_config_manager"
- Model switching errors between OpenRouter and Gemini